### PR TITLE
yank.sh updated for FreeBSD

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Installation
 -------------
 Prerequisites:
 - tmux >= "v2.4"
-- OSX, Linux (tested on Ubuntu 14 and CentOS7)
+- OSX, Linux (tested on Ubuntu 14 and CentOS7), FreeBSD (tested on 11.1)
 
 Personally, I use it on OSX 10.11.5 El Capitan through iTerm2.
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,18 @@ Tmux Configuration
 =====================
 Tmux configuration, that supercharges your [tmux](https://tmux.github.io/) and builds cozy and cool terminal environment.
 
+Contains minor updates by [Rafal Lukawiecki](https://github.com/rafallukawiecki) to the original created by [Alexey Samoshkin](https://github.com/samoshkin):
+ - Uses Solarized Dark palette colour names and choices.
+ - Prefers accent foreground colours to accented backgrounds to reduce contrasts jumps and permanently-on bright screen elements.
+ - F8 instead of F12 for 'Off' mode as F12 is bound to 'Dashboard' on some Apple MBPs (with TouchBar).
+ - European date format "Day Month" instead of "Month Day".
+ - duckduckgo.com instead of google.com as default search engine.
+ - Numeric IP (8.8.8.8) instead of FQDN as ping target for tmux-online-status.
+ - Original tmux wheel scrol speed of 5 lines, instead of 2.
+ - Binds C-a a for 'jump-to-line-start' command line editing.
+
+The remainder of the readme is from the upstream version of the config.
+
 ![intro](https://user-images.githubusercontent.com/768858/33152741-ec5f1270-cfe6-11e7-9570-6d17330a83aa.gif)
 
 Table of contents
@@ -281,7 +293,7 @@ If you are an iTerm2 user, third column describes the keybinding of similar  "ac
         <td>-</td>
     </tr>
     <tr>
-        <td><code>&lt;prefix&gt; F12</code></td>
+        <td><code>&lt;prefix&gt; F8</code></td>
         <td>Switch off all key binding and prefix hanling in current window. See "Nested sessions" paragraph for more info</td>
         <td>-</td>
     </tr>
@@ -330,7 +342,7 @@ Second attempt to tackle this issue, is to [setup 2 individual prefixes](https:/
 
 And finally accepted solution, turn off all keybindings and key prefix handling in outer session, when working with inner one. This way, outer session just sits aside, without interfering keystrokes passed to inner session. Credits to [http://stahlke.org/dan/tmux-nested/](http://stahlke.org/dan/tmux-nested/) and this [Github issue](https://github.com/tmux/tmux/issues/237)
 
-So, how it works. When in outer session, simply press `F12` to toggle off all keybindings handling in outer session. Now work with inner session using the same keybinding scheme and same keyprefix. Press `F12` to turn on outer session back.
+So, how it works. When in outer session, simply press `F8` to toggle off all keybindings handling in outer session. Now work with inner session using the same keybinding scheme and same keyprefix. Press `F8` to turn on outer session back.
 
 ![nested sessions](https://user-images.githubusercontent.com/768858/33151636-84a0bab2-cfe1-11e7-9d5d-412525689c9b.gif)
 
@@ -354,7 +366,6 @@ There is a root keybinding to enter Copy mode: `M-Up`. Once in copy mode, you ha
 - scroll by line: `M-Up`, `M-down`
 - scroll by half screen: `M-PageUp`, `M-PageDown`
 - scroll by whole screen: `PageUp`, `PageDown`
-- scroll by mouse wheel, scroll step is changed from `5` lines to `2`
 
 `Space` starts selection, `Enter` copies selection and exits copy mode. List all items in copy buffer using `prefix C-p`, and paste most recent item from buffer using `prexix p`.
 

--- a/readme.md
+++ b/readme.md
@@ -2,18 +2,6 @@ Tmux Configuration
 =====================
 Tmux configuration, that supercharges your [tmux](https://tmux.github.io/) and builds cozy and cool terminal environment.
 
-Contains minor updates by [Rafal Lukawiecki](https://github.com/rafallukawiecki) to the original created by [Alexey Samoshkin](https://github.com/samoshkin):
- - Uses Solarized Dark palette colour names and choices.
- - Prefers accent foreground colours to accented backgrounds to reduce contrasts jumps and permanently-on bright screen elements.
- - F8 instead of F12 for 'Off' mode as F12 is bound to 'Dashboard' on some Apple MBPs (with TouchBar).
- - European date format "Day Month" instead of "Month Day".
- - duckduckgo.com instead of google.com as default search engine.
- - Numeric IP (8.8.8.8) instead of FQDN as ping target for tmux-online-status.
- - Original tmux wheel scrol speed of 5 lines, instead of 2.
- - Binds C-a a for 'jump-to-line-start' command line editing.
-
-The remainder of the readme is from the upstream version of the config.
-
 ![intro](https://user-images.githubusercontent.com/768858/33152741-ec5f1270-cfe6-11e7-9570-6d17330a83aa.gif)
 
 Table of contents
@@ -293,7 +281,7 @@ If you are an iTerm2 user, third column describes the keybinding of similar  "ac
         <td>-</td>
     </tr>
     <tr>
-        <td><code>&lt;prefix&gt; F8</code></td>
+        <td><code>&lt;prefix&gt; F12</code></td>
         <td>Switch off all key binding and prefix hanling in current window. See "Nested sessions" paragraph for more info</td>
         <td>-</td>
     </tr>
@@ -342,7 +330,7 @@ Second attempt to tackle this issue, is to [setup 2 individual prefixes](https:/
 
 And finally accepted solution, turn off all keybindings and key prefix handling in outer session, when working with inner one. This way, outer session just sits aside, without interfering keystrokes passed to inner session. Credits to [http://stahlke.org/dan/tmux-nested/](http://stahlke.org/dan/tmux-nested/) and this [Github issue](https://github.com/tmux/tmux/issues/237)
 
-So, how it works. When in outer session, simply press `F8` to toggle off all keybindings handling in outer session. Now work with inner session using the same keybinding scheme and same keyprefix. Press `F8` to turn on outer session back.
+So, how it works. When in outer session, simply press `F12` to toggle off all keybindings handling in outer session. Now work with inner session using the same keybinding scheme and same keyprefix. Press `F12` to turn on outer session back.
 
 ![nested sessions](https://user-images.githubusercontent.com/768858/33151636-84a0bab2-cfe1-11e7-9d5d-412525689c9b.gif)
 
@@ -366,6 +354,7 @@ There is a root keybinding to enter Copy mode: `M-Up`. Once in copy mode, you ha
 - scroll by line: `M-Up`, `M-down`
 - scroll by half screen: `M-PageUp`, `M-PageDown`
 - scroll by whole screen: `PageUp`, `PageDown`
+- scroll by mouse wheel, scroll step is changed from `5` lines to `2`
 
 `Space` starts selection, `Enter` copies selection and exits copy mode. List all items in copy buffer using `prefix C-p`, and paste most recent item from buffer using `prexix p`.
 

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,8 +1,13 @@
+# RLL Changes
+bind a send-prefix
+
 # ==========================
 # ===  General settings  ===
 # ==========================
 
-set -g default-terminal "screen-256color"
+# set -g default-terminal "screen-256color"
+set -g default-terminal "xterm-256color"
+set-option -ga terminal-overrides ",*256col*:Tc"
 set -g history-limit 20000
 set -g buffer-limit 20
 set -sg escape-time 0
@@ -164,8 +169,8 @@ bind -T copy-mode-vi PageDown          send-keys -X page-down
 bind -T copy-mode-vi PageUp            send-keys -X page-up
 
 # When scrolling with mouse wheel, reduce number of scrolled rows per tick to "2" (default is 5)
-bind -T copy-mode-vi WheelUpPane       select-pane \; send-keys -X -N 2 scroll-up
-bind -T copy-mode-vi WheelDownPane     select-pane \; send-keys -X -N 2 scroll-down
+# bind -T copy-mode-vi WheelUpPane       select-pane \; send-keys -X -N 2 scroll-up
+# bind -T copy-mode-vi WheelDownPane     select-pane \; send-keys -X -N 2 scroll-down
 
 # wrap default shell in reattach-to-user-namespace if available
 # there is some hack with `exec & reattach`, credits to "https://github.com/gpakosz/.tmux"
@@ -203,29 +208,40 @@ bind -T copy-mode-vi MouseDown1Pane select-pane \;\
 
 # Feel free to NOT use this variables at all (remove, rename)
 # this are named colors, just for convenience
-color_orange="colour166" # 208, 166
-color_purple="colour134" # 135, 134
-color_green="colour076" # 070
-color_blue="colour39"
-color_yellow="colour220"
-color_red="colour160"
-color_black="colour232"
-color_white="white" # 015
+
+# RLL Added Solarized palette
+color_solarized_base03="colour234"
+color_solarized_base02="#073642"
+color_solarized_base01="colour240"
+color_solarized_base00="colour241"
+color_solarized_base0="colour244"
+color_solarized_base1="colour245"
+color_solarized_base2="colour254"
+color_solarized_base3="colour230"
+color_solarized_yellow="colour136"
+color_solarized_orange="colour166"
+color_solarized_red="colour160"
+color_solarized_magenta="colour125"
+color_solarized_violet="colour061"
+color_solarized_blue="colour033"
+color_solarized_cyan="colour037"
+color_solarized_green="colour064"
+color_solarized_white="colour230" # base3
 
 # This is a theme CONTRACT, you are required to define variables below
 # Change values, but not remove/rename variables itself
-color_dark="$color_black"
-color_light="$color_white"
-color_session_text="$color_blue"
-color_status_text="colour245"
-color_main="$color_orange"
-color_secondary="$color_purple"
-color_level_ok="$color_green"
-color_level_warn="$color_yellow"
-color_level_stress="$color_red"
-color_window_off_indicator="colour088"
-color_window_off_status_bg="colour238"
-color_window_off_status_current_bg="colour254"
+color_dark="$color_solarized_base02"
+color_light="$color_solarized_base2"
+color_session_text="$color_solarized_blue"
+color_status_text="$color_solarized_base1"
+color_main="$color_solarized_base01"
+color_secondary="$color_solarized_violet"
+color_level_ok="$color_solarized_green"
+color_level_warn="$color_solarized_yellow"
+color_level_stress="$color_solarized_red"
+color_window_off_indicator="$color_solarized_orange"
+color_window_off_status_bg="$color_solarized_base02"
+color_window_off_status_current_bg="$color_solarized_base01"
 
 # =====================================
 # ===    Appearence and status bar  ===
@@ -266,11 +282,11 @@ set -g status-right-length 100
 # note, that this is not the complete list, some of them are loaded from plugins
 wg_session="#[fg=$color_session_text] #S #[default]"
 wg_battery="#{battery_status_fg} #{battery_icon} #{battery_percentage}"
-wg_date="#[fg=$color_secondary]%h %d %H:%M#[default]"
+wg_date="#[fg=$color_secondary]%-d %h %H:%M#[default]"
 wg_user_host="#[fg=$color_secondary]#(whoami)#[default]@#H"
 wg_is_zoomed="#[fg=$color_dark,bg=$color_secondary]#{?window_zoomed_flag,[Z],}#[default]"
 # TODO: highlighted for nested local session as well
-wg_is_keys_off="#[fg=$color_light,bg=$color_window_off_indicator]#([ $(tmux show-option -qv key-table) = 'off' ] && echo 'OFF')#[default]"
+wg_is_keys_off="#[fg=$color_window_off_indicator]#([ $(tmux show-option -qv key-table) = 'off' ] && echo 'Off')#[default]"
 
 set -g status-left "$wg_session"
 set -g status-right "#{prefix_highlight} $wg_is_keys_off $wg_is_zoomed #{sysstat_cpu} | #{sysstat_mem} | #{sysstat_loadavg} | $wg_user_host | $wg_date $wg_battery #{online_status}"
@@ -280,7 +296,8 @@ set -g @online_icon "#[fg=$color_level_ok]●#[default]"
 set -g @offline_icon "#[fg=$color_level_stress]●#[default]"
 
 # Configure view templates for tmux-plugin-sysstat "MEM" and "CPU" widget
-set -g @sysstat_mem_view_tmpl 'MEM:#[fg=#{mem.color}]#{mem.pused}#[default] #{mem.used}'
+set -g @sysstat_mem_view_tmpl '#[fg=#{mem.color}]#{mem.pused}#[default] #{mem.used}'
+set -g @sysstat_cpu_view_tmpl '#[fg=#{cpu.color}]#{cpu.pused}#[default]'
 
 # Configure colors for tmux-plugin-sysstat "MEM" and "CPU" widget
 set -g @sysstat_cpu_color_low "$color_level_ok"
@@ -322,7 +339,8 @@ set -g update-environment \
   SSH_CONNECTION\
   SSH_TTY\
   WINDOWID\
-  XAUTHORITY"
+  XAUTHORITY\
+  COLORFGBG"
 
 bind '$' run "~/.tmux/renew_env.sh"
 
@@ -344,7 +362,8 @@ set -g @sidebar-tree 't'
 set -g @sidebar-tree-focus 'T'
 set -g @sidebar-tree-command 'tree -C'
 
-set -g @open-S 'https://www.google.com/search?q='
+set -g @open-S 'https://www.duckduckgo.com/search?q='
+set -g @route_to_ping '8.8.8.8'
 
 
 # ==============================================
@@ -363,7 +382,7 @@ if-shell 'test -n "$SSH_CLIENT"' \
 # see: toggle on/off all keybindings · Issue #237 · tmux/tmux - https://github.com/tmux/tmux/issues/237
 
 # Also, change some visual styles when window keys are off
-bind -T root F12  \
+bind -T root F8  \
     set prefix None \;\
     set key-table off \;\
     set status-style "fg=$color_status_text,bg=$color_window_off_status_bg" \;\
@@ -372,7 +391,7 @@ bind -T root F12  \
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
     refresh-client -S \;\
 
-bind -T off F12 \
+bind -T off F8 \
   set -u prefix \;\
   set -u key-table \;\
   set -u status-style \;\

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,13 +1,8 @@
-# RLL Changes
-bind a send-prefix
-
 # ==========================
 # ===  General settings  ===
 # ==========================
 
-# set -g default-terminal "screen-256color"
-set -g default-terminal "xterm-256color"
-set-option -ga terminal-overrides ",*256col*:Tc"
+set -g default-terminal "screen-256color"
 set -g history-limit 20000
 set -g buffer-limit 20
 set -sg escape-time 0
@@ -169,8 +164,8 @@ bind -T copy-mode-vi PageDown          send-keys -X page-down
 bind -T copy-mode-vi PageUp            send-keys -X page-up
 
 # When scrolling with mouse wheel, reduce number of scrolled rows per tick to "2" (default is 5)
-# bind -T copy-mode-vi WheelUpPane       select-pane \; send-keys -X -N 2 scroll-up
-# bind -T copy-mode-vi WheelDownPane     select-pane \; send-keys -X -N 2 scroll-down
+bind -T copy-mode-vi WheelUpPane       select-pane \; send-keys -X -N 2 scroll-up
+bind -T copy-mode-vi WheelDownPane     select-pane \; send-keys -X -N 2 scroll-down
 
 # wrap default shell in reattach-to-user-namespace if available
 # there is some hack with `exec & reattach`, credits to "https://github.com/gpakosz/.tmux"
@@ -208,40 +203,29 @@ bind -T copy-mode-vi MouseDown1Pane select-pane \;\
 
 # Feel free to NOT use this variables at all (remove, rename)
 # this are named colors, just for convenience
-
-# RLL Added Solarized palette
-color_solarized_base03="colour234"
-color_solarized_base02="#073642"
-color_solarized_base01="colour240"
-color_solarized_base00="colour241"
-color_solarized_base0="colour244"
-color_solarized_base1="colour245"
-color_solarized_base2="colour254"
-color_solarized_base3="colour230"
-color_solarized_yellow="colour136"
-color_solarized_orange="colour166"
-color_solarized_red="colour160"
-color_solarized_magenta="colour125"
-color_solarized_violet="colour061"
-color_solarized_blue="colour033"
-color_solarized_cyan="colour037"
-color_solarized_green="colour064"
-color_solarized_white="colour230" # base3
+color_orange="colour166" # 208, 166
+color_purple="colour134" # 135, 134
+color_green="colour076" # 070
+color_blue="colour39"
+color_yellow="colour220"
+color_red="colour160"
+color_black="colour232"
+color_white="white" # 015
 
 # This is a theme CONTRACT, you are required to define variables below
 # Change values, but not remove/rename variables itself
-color_dark="$color_solarized_base02"
-color_light="$color_solarized_base2"
-color_session_text="$color_solarized_blue"
-color_status_text="$color_solarized_base1"
-color_main="$color_solarized_base01"
-color_secondary="$color_solarized_violet"
-color_level_ok="$color_solarized_green"
-color_level_warn="$color_solarized_yellow"
-color_level_stress="$color_solarized_red"
-color_window_off_indicator="$color_solarized_orange"
-color_window_off_status_bg="$color_solarized_base02"
-color_window_off_status_current_bg="$color_solarized_base01"
+color_dark="$color_black"
+color_light="$color_white"
+color_session_text="$color_blue"
+color_status_text="colour245"
+color_main="$color_orange"
+color_secondary="$color_purple"
+color_level_ok="$color_green"
+color_level_warn="$color_yellow"
+color_level_stress="$color_red"
+color_window_off_indicator="colour088"
+color_window_off_status_bg="colour238"
+color_window_off_status_current_bg="colour254"
 
 # =====================================
 # ===    Appearence and status bar  ===
@@ -282,11 +266,11 @@ set -g status-right-length 100
 # note, that this is not the complete list, some of them are loaded from plugins
 wg_session="#[fg=$color_session_text] #S #[default]"
 wg_battery="#{battery_status_fg} #{battery_icon} #{battery_percentage}"
-wg_date="#[fg=$color_secondary]%-d %h %H:%M#[default]"
+wg_date="#[fg=$color_secondary]%h %d %H:%M#[default]"
 wg_user_host="#[fg=$color_secondary]#(whoami)#[default]@#H"
 wg_is_zoomed="#[fg=$color_dark,bg=$color_secondary]#{?window_zoomed_flag,[Z],}#[default]"
 # TODO: highlighted for nested local session as well
-wg_is_keys_off="#[fg=$color_window_off_indicator]#([ $(tmux show-option -qv key-table) = 'off' ] && echo 'Off')#[default]"
+wg_is_keys_off="#[fg=$color_light,bg=$color_window_off_indicator]#([ $(tmux show-option -qv key-table) = 'off' ] && echo 'OFF')#[default]"
 
 set -g status-left "$wg_session"
 set -g status-right "#{prefix_highlight} $wg_is_keys_off $wg_is_zoomed #{sysstat_cpu} | #{sysstat_mem} | #{sysstat_loadavg} | $wg_user_host | $wg_date $wg_battery #{online_status}"
@@ -296,8 +280,7 @@ set -g @online_icon "#[fg=$color_level_ok]●#[default]"
 set -g @offline_icon "#[fg=$color_level_stress]●#[default]"
 
 # Configure view templates for tmux-plugin-sysstat "MEM" and "CPU" widget
-set -g @sysstat_mem_view_tmpl '#[fg=#{mem.color}]#{mem.pused}#[default] #{mem.used}'
-set -g @sysstat_cpu_view_tmpl '#[fg=#{cpu.color}]#{cpu.pused}#[default]'
+set -g @sysstat_mem_view_tmpl 'MEM:#[fg=#{mem.color}]#{mem.pused}#[default] #{mem.used}'
 
 # Configure colors for tmux-plugin-sysstat "MEM" and "CPU" widget
 set -g @sysstat_cpu_color_low "$color_level_ok"
@@ -339,8 +322,7 @@ set -g update-environment \
   SSH_CONNECTION\
   SSH_TTY\
   WINDOWID\
-  XAUTHORITY\
-  COLORFGBG"
+  XAUTHORITY"
 
 bind '$' run "~/.tmux/renew_env.sh"
 
@@ -362,8 +344,7 @@ set -g @sidebar-tree 't'
 set -g @sidebar-tree-focus 'T'
 set -g @sidebar-tree-command 'tree -C'
 
-set -g @open-S 'https://www.duckduckgo.com/search?q='
-set -g @route_to_ping '8.8.8.8'
+set -g @open-S 'https://www.google.com/search?q='
 
 
 # ==============================================
@@ -382,7 +363,7 @@ if-shell 'test -n "$SSH_CLIENT"' \
 # see: toggle on/off all keybindings · Issue #237 · tmux/tmux - https://github.com/tmux/tmux/issues/237
 
 # Also, change some visual styles when window keys are off
-bind -T root F8  \
+bind -T root F12  \
     set prefix None \;\
     set key-table off \;\
     set status-style "fg=$color_status_text,bg=$color_window_off_status_bg" \;\
@@ -391,7 +372,7 @@ bind -T root F8  \
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
     refresh-client -S \;\
 
-bind -T off F8 \
+bind -T off F12 \
   set -u prefix \;\
   set -u key-table \;\
   set -u status-style \;\

--- a/tmux/yank.sh
+++ b/tmux/yank.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 
@@ -22,7 +22,10 @@ elif [ -n "${DISPLAY-}" ] && is_app_installed xsel; then
   copy_backend="xsel -i --clipboard"
 elif [ -n "${DISPLAY-}" ] && is_app_installed xclip; then
   copy_backend="xclip -i -f -selection primary | xclip -i -selection clipboard"
-elif [ -n "${copy_backend_remote_tunnel_port-}" ] && [ "$(ss -n -4 state listening "( sport = $copy_backend_remote_tunnel_port )" | tail -n +2 | wc -l)" -eq 1 ]; then
+# Check if ss installed, as there is no native ss on FreeBSD (use sockstat instead)
+elif [ -n "${copy_backend_remote_tunnel_port-}" ] && is_app_installed ss && [ "$(ss -n -4 state listening "( sport = $copy_backend_remote_tunnel_port )" | tail -n +2 | wc -l)" -eq 1 ]; then
+  copy_backend="nc localhost $copy_backend_remote_tunnel_port"
+elif [ -n "${copy_backend_remote_tunnel_port-}" ] && is_app_installed sockstat && sockstat -4 -l | grep -q ":$copy_backend_remote_tunnel_port" ; then
   copy_backend="nc localhost $copy_backend_remote_tunnel_port"
 fi
 


### PR DESCRIPTION
There is no `ss` natively on FreeBSD, but there is `sockstat`. This was making yank.sh fail. I have added another elif clause and a check for ss and sockstat presence, as yank.sh was failing. Also the usual replacement of #!/bin/bash with #!/usr/bin/env bash. Bear in mind that I use OSC52, and not xclip etc, as I do not use X11, only text mode, on remote servers. I have tested that elif clause using a different port to make sure it works, but I have not tested it with xclip. My `grep -q` test simply checks if there is a listening port, I am not sure if you need to test for anything more—I see you are using a more complex expression than mine with ` | tail -n +2 | wc -l`, but I do not know why, as I cannot see what those two lines would contain.

Feel free to combine lines 26-29—I did not want to change your code too much.

Many thanks for creating your yank.sh script.

PS. I would keep this pending till tmux-online-status PR has merged.