### PR TITLE
Update tmux.conf so it conforms to tmux3 & 2 style

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -38,8 +38,8 @@ unbind "\$" # rename-session
 unbind ,    # rename-window
 unbind %    # split-window -h
 unbind '"'  # split-window
-unbind }    # swap-pane -D
-unbind {    # swap-pane -U
+unbind '}'    # swap-pane -D
+unbind '{'    # swap-pane -U
 unbind [    # paste-buffer
 unbind ]    
 unbind "'"  # select-window
@@ -95,7 +95,7 @@ bind L command-prompt -p "Link window from (session:window): " "link-window -s %
 
 # Swap panes back and forth with 1st pane
 # When in main-(horizontal|vertical) layouts, the biggest/widest panel is always @1
-bind \ if '[ #{pane_index} -eq 1 ]' \
+bind '\' if '[ #{pane_index} -eq 1 ]' \
      'swap-pane -s "!"' \
      'select-pane -t:.1 ; swap-pane -d -t 1 -s "!"'
 


### PR DESCRIPTION
The new format for tmux3 has listed two incompatible changes as follow ([source](https://github.com/tmux/tmux/blob/master/CHANGES))

>INCOMPATIBLE: tmux's configuration parsing has changed to use yacc(1). There is one incompatible change: a \ on its own must be escaped or quoted as either \\ or '\' (the latter works on older tmux versions).
>INCOMPATIBLE: Add a new {} syntax to the configuration file. This is a string similar to single quotes but also includes newlines and allows commands that take other commands as string arguments to be expressed more clearly and without additional escaping.

So now ``{``, ``}`` and ``\`` have to be escaped to ``'{'``, ``'}'`` and ``'\'`` (to maintain compatibility with tmux2)