### PR TITLE
Added slashes so it work on at least 3.0a

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -38,8 +38,8 @@ unbind "\$" # rename-session
 unbind ,    # rename-window
 unbind %    # split-window -h
 unbind '"'  # split-window
-unbind }    # swap-pane -D
-unbind {    # swap-pane -U
+unbind \}    # swap-pane -D
+unbind \{    # swap-pane -U
 unbind [    # paste-buffer
 unbind ]    
 unbind "'"  # select-window
@@ -95,7 +95,7 @@ bind L command-prompt -p "Link window from (session:window): " "link-window -s %
 
 # Swap panes back and forth with 1st pane
 # When in main-(horizontal|vertical) layouts, the biggest/widest panel is always @1
-bind \ if '[ #{pane_index} -eq 1 ]' \
+bind \\ if '[ #{pane_index} -eq 1 ]' \
      'swap-pane -s "!"' \
      'select-pane -t:.1 ; swap-pane -d -t 1 -s "!"'
 


### PR DESCRIPTION
Seems to be a common thing that you get a syntax error on line 21, 22 and 100. I forget every time I reinstall on a new box. So I made this quick edit to make it work.

Haven't found any other glaring bugs on 3.0a but I'm not much of a power user though... This fix at least makes it work out-of-the-box on 3.0a in Ubuntu 20.04